### PR TITLE
change on displaying image in listview

### DIFF
--- a/config/custom/static/images.js
+++ b/config/custom/static/images.js
@@ -1,11 +1,9 @@
 
 $(function () {
     // show all images inside the ListView
-    $('.x-table tbody tr').each(function (index) {
-        // the image column is second
-        var td =  $('td:eq(1)', this);
+    $('.x-table tbody [type=image]').each(function (index) {
         // get the image url
-        var url = td.text().trim();
+        var url = $(this).text().trim();
 
         // skip on missing url
         if (!url) return;
@@ -13,7 +11,7 @@ $(function () {
         if (!url.match(/^http/)) url = '/upload/' + url;
 
         // add image to this table cell
-        td.html('<img src="'+url+'" style="width:100px" />');
+        $(this).html('<img src="'+url+'" style="width:100px" />');
     });
 
     // show all images inside the EditView


### PR DESCRIPTION
In showing images in listview, I found it is hard-coded in 'images.js' to force the 2nd column of listview to display as an image item. It does not display images in any other columns, and also it causes any text field in the 2nd column unable to display properly.

I fixed this by adding a change in 'express-admin', and utilizing that change in config/custom/static/images.js.